### PR TITLE
[Feat] #60 - cafe information image slide

### DIFF
--- a/app/src/main/java/org/cazait/cazait_android/ui/view/cafelist/info/CafeInformationActivity.kt
+++ b/app/src/main/java/org/cazait/cazait_android/ui/view/cafelist/info/CafeInformationActivity.kt
@@ -6,6 +6,8 @@ import android.view.MenuItem
 import android.widget.Button
 import androidx.activity.viewModels
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import dagger.hilt.android.AndroidEntryPoint
 import org.cazait.cazait_android.R
@@ -66,6 +68,21 @@ class CafeInformationActivity : BaseActivity<ActivityCafeInformationBinding, Caf
         binding.fabReviewWrite.setOnClickListener {
             val intent = Intent(this, CafeRatingReviewEditActivity::class.java)
             startActivity(intent)
+        }
+
+        val pagerAdapter = ScreenSlidePagerAdapter(this)
+        binding.vpImg.adapter = pagerAdapter
+    }
+
+    private inner class ScreenSlidePagerAdapter(fa: FragmentActivity) : FragmentStateAdapter(fa) {
+        override fun getItemCount(): Int = Int.MAX_VALUE
+
+        override fun createFragment(position: Int): Fragment {
+            return when (position % 3) {
+                0 -> ImageSlideFragment(R.drawable.image_cafe_ex1)
+                1 -> ImageSlideFragment(R.drawable.image_cafe_ex1)
+                else -> ImageSlideFragment(R.drawable.image_cafe_ex1)
+            }
         }
     }
 

--- a/app/src/main/java/org/cazait/cazait_android/ui/view/cafelist/info/inner/CafeRatingReviewFragment.kt
+++ b/app/src/main/java/org/cazait/cazait_android/ui/view/cafelist/info/inner/CafeRatingReviewFragment.kt
@@ -1,7 +1,5 @@
 package org.cazait.cazait_android.ui.view.cafelist.info.inner
 
-import android.app.AlertDialog
-import android.widget.Toast
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -41,7 +39,7 @@ class CafeRatingReviewFragment :
     }
 
     private fun observeReviewListData() {
-        viewModel.reviewList.observe(this){
+        viewModel.reviewList.observe(this) {
             reviewAdapter.data = it
         }
     }

--- a/app/src/main/java/org/cazait/cazait_android/ui/view/cafelist/info/inner/CafeRatingReviewFragment.kt
+++ b/app/src/main/java/org/cazait/cazait_android/ui/view/cafelist/info/inner/CafeRatingReviewFragment.kt
@@ -31,26 +31,7 @@ class CafeRatingReviewFragment :
 
     override fun initView() {
         initRecyclerView()
-
-//        binding.tvFilter.setOnClickListener {
-//            showDialog()
-//        }
-//        binding.imgbtnFilter.setOnClickListener {
-//            showDialog()
-//        }
     }
-
-    // 정렬 기준 선택 다이얼로그
-//    private fun showDialog(){
-//        val sortMenu:Array<String> = resources.getStringArray(R.array.sortmenu)
-//        val builder: AlertDialog.Builder = AlertDialog.Builder(context)
-//        builder.setTitle("정렬 메뉴")
-//        builder.setItems(sortMenu){ p0, p1 ->
-//            Toast.makeText(context, "선택된 정렬 기준은 ${sortMenu[p1]}", Toast.LENGTH_LONG).show()
-//        }
-//        val alertDialog:AlertDialog = builder.create()
-//        alertDialog.show()
-//    }
 
     private fun initRecyclerView() {
         reviewAdapter = CafeInfoReviewAdapter()

--- a/app/src/main/java/org/cazait/cazait_android/ui/view/cafelist/info/inner/ImageSlideFragment.kt
+++ b/app/src/main/java/org/cazait/cazait_android/ui/view/cafelist/info/inner/ImageSlideFragment.kt
@@ -1,0 +1,33 @@
+package org.cazait.cazait_android.ui.view.cafelist.info.inner
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import dagger.hilt.android.AndroidEntryPoint
+import org.cazait.cazait_android.R
+import org.cazait.cazait_android.databinding.FragmentImageSlideBinding
+import org.cazait.cazait_android.ui.base.BaseFragment
+import org.cazait.cazait_android.ui.viewmodel.CafeInfoImgViewModel
+
+@AndroidEntryPoint
+class ImageSlideFragment(val image: Int) :
+    BaseFragment<FragmentImageSlideBinding, CafeInfoImgViewModel>() {
+    override val layoutResourceId: Int
+        get() = R.layout.fragment_image_slide
+
+    override val viewModel: CafeInfoImgViewModel by viewModels()
+    override fun initView() {
+        binding.imgSlide.setImageResource(image)
+    }
+
+    override fun initBeforeBinding() {
+
+    }
+
+    override fun initAfterBinding() {
+
+    }
+}

--- a/app/src/main/java/org/cazait/cazait_android/ui/view/cafelist/info/inner/ImageSlideFragment.kt
+++ b/app/src/main/java/org/cazait/cazait_android/ui/view/cafelist/info/inner/ImageSlideFragment.kt
@@ -1,10 +1,5 @@
 package org.cazait.cazait_android.ui.view.cafelist.info.inner
 
-import android.os.Bundle
-import androidx.fragment.app.Fragment
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import org.cazait.cazait_android.R

--- a/app/src/main/java/org/cazait/cazait_android/ui/viewmodel/CafeInfoImgViewModel.kt
+++ b/app/src/main/java/org/cazait/cazait_android/ui/viewmodel/CafeInfoImgViewModel.kt
@@ -1,0 +1,11 @@
+package org.cazait.cazait_android.ui.viewmodel
+
+import dagger.hilt.android.lifecycle.HiltViewModel
+import org.cazait.cazait_android.data.repository.DataRepositorySource
+import org.cazait.cazait_android.ui.base.BaseViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class CafeInfoImgViewModel @Inject constructor(private val dataRepository: DataRepositorySource) :
+    BaseViewModel() {
+}

--- a/app/src/main/res/layout/activity_cafe_information.xml
+++ b/app/src/main/res/layout/activity_cafe_information.xml
@@ -29,19 +29,19 @@
                     app:contentScrim="@android:color/transparent"
                     app:layout_scrollFlags="scroll|exitUntilCollapsed">
 
-                    <ImageView
+                    <androidx.viewpager2.widget.ViewPager2
+                        android:id="@+id/vp_Img"
                         android:layout_width="match_parent"
-                        android:layout_height="230dp"
-                        android:contentDescription="@null"
-                        android:scaleType="centerCrop"
-                        android:src="@drawable/image_cafe_ex1"
+                        android:layout_height="match_parent"
+                        android:layout_gravity="center"
                         app:layout_collapseMode="parallax" />
+
 
                     <androidx.appcompat.widget.Toolbar
                         android:layout_width="match_parent"
                         android:layout_height="0dp"
                         android:theme="@style/ThemeOverlay.AppCompat.Dark"
-                        app:layout_collapseMode="pin"/>
+                        app:layout_collapseMode="pin" />
                 </com.google.android.material.appbar.CollapsingToolbarLayout>
             </com.google.android.material.appbar.AppBarLayout>
 
@@ -62,30 +62,30 @@
                         android:id="@+id/tv_cafe_info_name"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:text="@string/cafe_info_name"
-                        android:textSize="26sp"
-                        android:textColor="@color/cazait_black"
                         android:layout_marginStart="27dp"
                         android:layout_marginTop="10dp"
-                        app:layout_constraintTop_toTopOf="parent"
+                        android:text="@string/cafe_info_name"
+                        android:textColor="@color/cazait_black"
+                        android:textSize="26sp"
                         app:layout_constraintBottom_toTopOf="@id/tv_cafe_info_add"
+                        app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintEnd_toEndOf="parent"/>
+                        app:layout_constraintTop_toTopOf="parent" />
 
                     <TextView
                         android:id="@+id/tv_cafe_info_add"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:text="@string/cafe_info_address"
-                        android:textSize="13sp"
-                        android:textColor="@color/cazait_black"
                         android:layout_marginStart="27dp"
                         android:layout_marginTop="3dp"
                         android:layout_marginBottom="10dp"
-                        app:layout_constraintTop_toBottomOf="@id/tv_cafe_info_name"
+                        android:text="@string/cafe_info_address"
+                        android:textColor="@color/cazait_black"
+                        android:textSize="13sp"
                         app:layout_constraintBottom_toTopOf="@id/linearLayout"
+                        app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintEnd_toEndOf="parent"/>
+                        app:layout_constraintTop_toBottomOf="@id/tv_cafe_info_name" />
 
 
                     <LinearLayout
@@ -96,9 +96,9 @@
                         android:baselineAligned="false"
                         android:gravity="center"
                         android:orientation="horizontal"
-                        android:weightSum="3"
                         android:paddingStart="18.32dp"
                         android:paddingEnd="18.32dp"
+                        android:weightSum="3"
                         app:layout_constraintBottom_toTopOf="@id/cafe_info_frag_con"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
@@ -120,9 +120,9 @@
                                 android:textSize="16sp"
                                 android:textStyle="bold"
                                 app:layout_constraintBottom_toBottomOf="parent"
+                                app:layout_constraintEnd_toEndOf="parent"
                                 app:layout_constraintStart_toStartOf="parent"
-                                app:layout_constraintTop_toTopOf="parent"
-                                app:layout_constraintEnd_toEndOf="parent"/>
+                                app:layout_constraintTop_toTopOf="parent" />
                         </androidx.constraintlayout.widget.ConstraintLayout>
 
                         <androidx.constraintlayout.widget.ConstraintLayout
@@ -143,7 +143,7 @@
                                 app:layout_constraintBottom_toBottomOf="parent"
                                 app:layout_constraintEnd_toEndOf="parent"
                                 app:layout_constraintStart_toStartOf="parent"
-                                app:layout_constraintTop_toTopOf="parent"/>
+                                app:layout_constraintTop_toTopOf="parent" />
                         </androidx.constraintlayout.widget.ConstraintLayout>
 
                         <androidx.constraintlayout.widget.ConstraintLayout
@@ -164,19 +164,19 @@
                                 app:layout_constraintBottom_toBottomOf="parent"
                                 app:layout_constraintEnd_toEndOf="parent"
                                 app:layout_constraintStart_toStartOf="parent"
-                                app:layout_constraintTop_toTopOf="parent"/>
+                                app:layout_constraintTop_toTopOf="parent" />
                         </androidx.constraintlayout.widget.ConstraintLayout>
                     </LinearLayout>
 
                     <androidx.fragment.app.FragmentContainerView
                         android:id="@+id/cafe_info_frag_con"
+                        android:name="org.cazait.cazait_android.ui.view.cafelist.info.inner.CafeMenuFragment"
                         android:layout_width="match_parent"
                         android:layout_height="0dp"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@+id/linearLayout"
-                        android:name="org.cazait.cazait_android.ui.view.cafelist.info.inner.CafeMenuFragment"
                         tools:layout="@layout/fragment_cafe_menu" />
 
                 </androidx.constraintlayout.widget.ConstraintLayout>
@@ -190,10 +190,10 @@
             android:layout_marginEnd="7dp"
             android:layout_marginBottom="17dp"
             android:backgroundTint="@color/rating_review_edit"
+            android:contentDescription="@null"
             android:src="@drawable/cafe_info_rating_review_edit"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            android:contentDescription="@null" />
+            app:layout_constraintEnd_toEndOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_image_slide.xml
+++ b/app/src/main/res/layout/fragment_image_slide.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="230dp"
+        tools:context=".ui.view.cafelist.info.inner.ImageSlideFragment">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <ImageView
+                android:id="@+id/img_slide"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:scaleType="fitXY"
+                android:src="@drawable/image_cafe_ex1"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </FrameLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,15 +22,15 @@
 
     <string name="cafelist1_name">롬곡</string>
     <string name="cafelist1_dis">220m</string>
-    <string name="cafelist1_add">서울특별시 광진구 광나루로 375-1 2층(군자동)</string>
+    <string name="cafelist1_add">서울특별시 광진구 광나루로 375–1 2층(군자동)</string>
 
     <string name="cafelist2_name">제주몰빵</string>
     <string name="cafelist2_dis">1500m</string>
-    <string name="cafelist2_add">서울특별시 광진구 광나루로 375-1 2층(군자동)</string>
+    <string name="cafelist2_add">서울특별시 광진구 광나루로 375–1 2층(군자동)</string>
 
     <string name="cafelist3_name">팬도로시</string>
     <string name="cafelist3_dis">2000m</string>
-    <string name="cafelist3_add">서울특별시 광진구 광나루로 375-1 2층(군자동)</string>
+    <string name="cafelist3_add">서울특별시 광진구 광나루로 375–1 2층(군자동)</string>
 
     <!--login activity-->
     <string name="login_login">LOGIN</string>


### PR DESCRIPTION
## Cafe Information Image Slide
- 카페 상세 페이지에서 이미지 여러 장을 가로로 스크롤 할 수 있도록 했습니다.
- Circle Indicator를 적용하고자 했지만 CollapseToolbarLayout 내부에는 Toolbar를 제외하고 2개 이상의 view는 배치를 못하는 것 같습니다.
- CafeInformationActivity의 전체적인 구조

```
<CoordinatorLayout>   << CollapsingToolbarLayout을 사용하기 위해서는 꼭 CoordinatorLayout을 사용해야함
    <AppBarLayout>   << appBarLayout 안에 CollapsingToolbarLayout을 넣음   
    	<CollapsingToolbarLayout>   << 스크롤시 접히거나 나타날 부분을 넣는 layout        
            <ViewPager2/>            << 접히거나 나타날 이미지            
            <Toolbar/>              << 접혔을 때에도 남아있을 툴바            
        </CollapsingToolbarLayout>    
    </AppBarLayout>    
    <NestedScrollView>   << 스크롤할 뷰 (ViewPager2나 RecyclerView도 가능)
        <LinearLayout> 기타 등등
    </NestedScrollView>
</CoordinatorLayout>
```